### PR TITLE
Fix typo in HasValue comment

### DIFF
--- a/src/Recommerce/Recommerce.Infrastructure/Extensions/StringExtensions.cs
+++ b/src/Recommerce/Recommerce.Infrastructure/Extensions/StringExtensions.cs
@@ -113,7 +113,7 @@ public static class StringExtensions
     }
 
     /// <summary>
-    /// return true if entered string has any value (expect space characters only!)
+    /// return true if entered string has any value (except space characters only!)
     /// </summary>
     /// <param name="input"></param>
     /// <returns></returns>


### PR DESCRIPTION
## Summary
- fix typo in `StringExtensions.HasValue` summary

## Testing
- `dotnet test src/Recommerce/Recommerce.sln` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_b_6898f69957a8832f92865ea499dc3b73