### PR TITLE
docs: add database and messaging ADR

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ If you are looking for a recommender system that can be installed independently 
 - [Artificial Intelligence Techniques](#artificial-intelligence-techniques)
 - [Support](#support)
 - [Contribution](#contribution)
+- [Architecture Decision Records](#architecture-decision-records)
 - [License](#license)
 ## How it Works
 The recommender system offers the best products expected by the user by analyzing the following factors:
@@ -199,6 +200,12 @@ If you are not able to contribute code or documentation, you can still contribut
 
 We appreciate all contributions to the project, big or small. Thank you for helping us make Logic a better product recommender system! 
 **Thank you for your contributions! ❤️**
+
+## Architecture Decision Records
+
+Architecture decisions are documented in the [adr](adr/) directory.
+
+- [0001-database-and-messaging](adr/0001-database-and-messaging.md)
 
 ## License
 This project is made available under the MIT license. See [LICENSE](https://github.com/sajjadsaharkhan/Recommerce/blob/main/LICENSE) for details.

--- a/adr/0001-database-and-messaging.md
+++ b/adr/0001-database-and-messaging.md
@@ -1,0 +1,15 @@
+# 0001: Database and Messaging
+
+## Status
+Accepted
+
+## Context
+The project requires a reliable relational database and a message broker to coordinate work between bounded contexts. The database must be widely supported in the .NET ecosystem and integrate well with tooling. For messaging, we need a broker and library that provide durable delivery and simple integration with .NET services.
+
+## Decision
+Use **Microsoft SQL Server** as the primary relational database and **RabbitMQ** with **MassTransit** for asynchronous messaging.
+
+## Consequences
+- SQL Server becomes a core dependency and influences deployment and local development environments.
+- RabbitMQ and MassTransit add operational overhead but give us reliable, durable messaging and a rich ecosystem.
+- Future changes to database or messaging technologies will require new ADRs to capture the trade‑offs.


### PR DESCRIPTION
## Summary
- record decision to use SQL Server and RabbitMQ/MassTransit
- surface ADRs in README for visibility

## Testing
- `dotnet build src/Recommerce/Recommerce.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68990910e474832fa35d561a9848f5e6