### PR TITLE
Fix exception propagation in Result helpers

### DIFF
--- a/src/Recommerce/Recommerce.Infrastructure/Rop/Result.cs
+++ b/src/Recommerce/Recommerce.Infrastructure/Rop/Result.cs
@@ -40,7 +40,7 @@ public class Result
 
     public static Result Failed(BaseException exception, params string[] messages)
     {
-        return new Result(false,  null!, messages);
+        return new Result(false, exception, messages);
     }
     
     // wrap Custom Exceptions into Result
@@ -81,7 +81,7 @@ public class Result<TSuccess> : Result
 
     public new static Result<TSuccess> Failed(BaseException exception, params string[] messages)
     {
-        return new Result<TSuccess>(false, default!, null!, messages);
+        return new Result<TSuccess>(false, default!, exception, messages);
     }
 
     


### PR DESCRIPTION
## Summary
- ensure Result.Failed methods retain passed exception

## Testing
- `dotnet test src/Recommerce/Recommerce.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `curl -L https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh` *(fails: CONNECT tunnel 403)*

------
https://chatgpt.com/codex/tasks/task_b_6898eede4150832fb6dbb84f3217ad60