### PR TITLE
Add ProductService unit tests

### DIFF
--- a/src/Recommerce.Tests/ProductServiceTests.cs
+++ b/src/Recommerce.Tests/ProductServiceTests.cs
@@ -1,0 +1,60 @@
+using System.Threading;
+using System.Threading.Tasks;
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Recommerce.Data.DbContexts;
+using Recommerce.Data.Entities;
+using Recommerce.Infrastructure.Exceptions;
+using Recommerce.Services.Products.Implementations;
+using Xunit;
+
+namespace Recommerce.Tests;
+
+public class ProductServiceTests
+{
+    private readonly AppDbContext _dbContext;
+    private readonly ProductService _productService;
+
+    public ProductServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase("ProductServiceTests")
+            .Options;
+
+        _dbContext = new AppDbContext(options);
+
+        var publishEndpoint = new Mock<IPublishEndpoint>().Object;
+        _productService = new ProductService(_dbContext, publishEndpoint);
+    }
+
+    [Fact]
+    public async Task GetProductIdAsync_WhenIdentifierMissing_ReturnsEntityNotFound()
+    {
+        // Arrange
+        var product = new Product
+        {
+            UniqueIdentifier = "existing",
+            Name = "Existing Product",
+            Price = 1
+        };
+        _dbContext.Products.Add(product);
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        var resultMissing = await _productService.GetProductIdAsync(
+            new[] { product.UniqueIdentifier, "missing" }, CancellationToken.None);
+
+        // Assert failure
+        Assert.True(resultMissing.IsFailed);
+        Assert.IsType<EntityNotFoundException<Product>>(resultMissing.Exception);
+
+        // Act success
+        var resultSuccess = await _productService.GetProductIdAsync(
+            new[] { product.UniqueIdentifier }, CancellationToken.None);
+
+        // Assert success
+        Assert.True(resultSuccess.IsSuccess);
+        Assert.Equal(product.Id, resultSuccess.Data[product.UniqueIdentifier]);
+    }
+}

--- a/src/Recommerce.Tests/Recommerce.Tests.csproj
+++ b/src/Recommerce.Tests/Recommerce.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Recommerce\Recommerce.Services\Recommerce.Services.csproj" />
+    <ProjectReference Include="..\Recommerce\Recommerce.Data\Recommerce.Data.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Moq" Version="4.20.1" />
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/src/Recommerce/Recommerce.Services/Products/Implementations/ProductService.cs
+++ b/src/Recommerce/Recommerce.Services/Products/Implementations/ProductService.cs
@@ -108,7 +108,7 @@ public class ProductService : IProductService
             .ToDictionaryAsync(keySelector => keySelector.UniqueIdentifier, valueSelector => valueSelector.Id,
                 cancellationToken);
 
-        if (productsIdDictionary.Count == productIdentifierList.Count())
+        if (productsIdDictionary.Count != productIdentifierList.Count())
             return new EntityNotFoundException<Product>();
 
         return productsIdDictionary;

--- a/src/Recommerce/Recommerce.sln
+++ b/src/Recommerce/Recommerce.sln
@@ -8,6 +8,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Recommerce.Infrastructure",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Recommerce.Services", "Recommerce.Services\Recommerce.Services.csproj", "{A6402BB9-5EFE-4B7A-A543-851B7581D241}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Recommerce.Tests", "..\Recommerce.Tests\Recommerce.Tests.csproj", "{3D4D0677-EA23-495E-987B-D6372A4C1ABC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,5 +32,9 @@ Global
 		{A6402BB9-5EFE-4B7A-A543-851B7581D241}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A6402BB9-5EFE-4B7A-A543-851B7581D241}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A6402BB9-5EFE-4B7A-A543-851B7581D241}.Release|Any CPU.Build.0 = Release|Any CPU
+                {3D4D0677-EA23-495E-987B-D6372A4C1ABC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {3D4D0677-EA23-495E-987B-D6372A4C1ABC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {3D4D0677-EA23-495E-987B-D6372A4C1ABC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {3D4D0677-EA23-495E-987B-D6372A4C1ABC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- add new test project with ProductServiceTests
- fix GetProductIdAsync to throw when identifiers are missing

## Testing
- `dotnet test src/Recommerce/Recommerce.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6899ab981fec832f8bfbbb57323ba1ad