### PR TITLE
Fix product ID retrieval condition in ProductService

### DIFF
--- a/src/Recommerce/Recommerce.Services/Products/Implementations/ProductService.cs
+++ b/src/Recommerce/Recommerce.Services/Products/Implementations/ProductService.cs
@@ -108,7 +108,7 @@ public class ProductService : IProductService
             .ToDictionaryAsync(keySelector => keySelector.UniqueIdentifier, valueSelector => valueSelector.Id,
                 cancellationToken);
 
-        if (productsIdDictionary.Count == productIdentifierList.Count())
+        if (productsIdDictionary.Count != productIdentifierList.Count())
             return new EntityNotFoundException<Product>();
 
         return productsIdDictionary;


### PR DESCRIPTION
## Summary
- Correct product ID lookup logic to only throw when identifiers are missing

## Testing
- `dotnet test src/Recommerce/Recommerce.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_b_6899ab9714bc832f82212a4569735c3c